### PR TITLE
Javadoc and Sonar cleanup

### DIFF
--- a/src/main/java/org/kiwiproject/dynamicproperties/PropertyExtractor.java
+++ b/src/main/java/org/kiwiproject/dynamicproperties/PropertyExtractor.java
@@ -1,24 +1,22 @@
 package org.kiwiproject.dynamicproperties;
 
+import static java.util.Arrays.stream;
+import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.ArrayUtils.isNotEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.kiwiproject.reflect.KiwiReflection.nonStaticFieldsInHierarchy;
 
-import static java.util.Arrays.stream;
-import static java.util.Collections.emptyList;
-
-import java.lang.reflect.Field;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-
+import lombok.experimental.UtilityClass;
 import org.kiwiproject.dynamicproperties.annotation.DynamicField;
 import org.kiwiproject.dynamicproperties.annotation.EnumUnit;
 import org.kiwiproject.dynamicproperties.annotation.Unit;
 import org.kiwiproject.validation.Required;
 
-import lombok.experimental.UtilityClass;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 
 @UtilityClass
 public class PropertyExtractor {
@@ -36,14 +34,14 @@ public class PropertyExtractor {
         var dynamicFieldAnnotation = findDynamicFieldAnnotation(field);
 
         var property = Property.builder()
-            .name(field.getName())
-            .type(fieldClass.getSimpleName())
-            .values(getPossibleValuesForField(fieldClass, dynamicFieldAnnotation))
-            .visible(dynamicFieldAnnotation.visible())
-            .editable(dynamicFieldAnnotation.editable())
-            .label(dynamicFieldAnnotation.label())
-            .required(isFieldRequired(field))
-            .build();
+                .name(field.getName())
+                .type(fieldClass.getSimpleName())
+                .values(getPossibleValuesForField(fieldClass, dynamicFieldAnnotation))
+                .visible(dynamicFieldAnnotation.visible())
+                .editable(dynamicFieldAnnotation.editable())
+                .label(dynamicFieldAnnotation.label())
+                .required(isFieldRequired(field))
+                .build();
 
         addUnitInformationIfNecessary(property, field);
 
@@ -64,22 +62,22 @@ public class PropertyExtractor {
 
     private static List<String> getListFromEnum(Class<?> enumClass) {
         return stream(enumClass.getEnumConstants())
-                    .filter(val -> val instanceof Enum)
-                    .map(val -> ((Enum<?>) val).name())
-                    .collect(toList());
+                .filter(val -> val instanceof Enum)
+                .map(val -> ((Enum<?>) val).name())
+                .collect(toList());
     }
 
     private static DynamicField findDynamicFieldAnnotation(Field field) {
         return stream(field.getAnnotations())
-            .filter(annotation -> annotation instanceof DynamicField)
-            .map(annotation -> (DynamicField) annotation)
-            .findFirst()
-            .orElseThrow();
+                .filter(annotation -> annotation instanceof DynamicField)
+                .map(DynamicField.class::cast)
+                .findFirst()
+                .orElseThrow();
     }
 
     private static boolean isFieldRequired(Field field) {
         return stream(field.getAnnotations())
-            .anyMatch(annotation -> annotation instanceof Required);
+                .anyMatch(annotation -> annotation instanceof Required);
     }
 
     private static void addUnitInformationIfNecessary(Property property, Field field) {
@@ -96,16 +94,16 @@ public class PropertyExtractor {
 
     private static Optional<Unit> findUnitAnnotation(Field field) {
         return stream(field.getAnnotations())
-            .filter(annotation -> annotation instanceof Unit)
-            .map(annotation -> (Unit) annotation)
-            .findFirst();
+                .filter(annotation -> annotation instanceof Unit)
+                .map(Unit.class::cast)
+                .findFirst();
     }
 
     private static Optional<EnumUnit> findEnumUnitAnnotation(Field field) {
         return stream(field.getAnnotations())
-            .filter(annotation -> annotation instanceof EnumUnit)
-            .map(annotation -> (EnumUnit) annotation)
-            .findFirst();
+                .filter(annotation -> annotation instanceof EnumUnit)
+                .map(EnumUnit.class::cast)
+                .findFirst();
     }
 
     private static void processUnitAnnotation(Unit unitAnnotation, Property property) {

--- a/src/main/java/org/kiwiproject/dynamicproperties/annotation/DynamicField.java
+++ b/src/main/java/org/kiwiproject/dynamicproperties/annotation/DynamicField.java
@@ -16,21 +16,29 @@ public @interface DynamicField {
 
     /**
      * Informs the caller if this field should be displayed.
+     *
+     * @return true if this field should be displayed, false otherwise
      */
     boolean visible() default true;
 
     /**
-     * Informs the caller if this field should be ediable.
+     * Informs the caller if this field should be editable.
+     *
+     * @return true if this field is editable, false otherwise
      */
     boolean editable() default true;
 
     /**
-     * Provide a custom label if it needs to be different than the human readable form of the field.
+     * Provide a custom label if it needs to be different from the human-readable form of the field.
+     *
+     * @return the label text, defaults to an empty string
      */
     String label() default "";
 
     /**
      * Provide a list of possible values for this field. Useful if field is restricted to a set of values.
+     *
+     * @return the choices that should be available for this field, default is empty array
      */
     String[] choices() default {};
 

--- a/src/main/java/org/kiwiproject/dynamicproperties/annotation/EnumUnit.java
+++ b/src/main/java/org/kiwiproject/dynamicproperties/annotation/EnumUnit.java
@@ -15,12 +15,16 @@ import java.lang.annotation.Target;
 public @interface EnumUnit {
 
     /**
-     * Set the concrete list of units allowed for this field.
+     * Set the enum class containing units allowed for this field.
+     *
+     * @return the enum type containing allowed units
      */
     Class<? extends Enum<?>> value();
 
     /**
      * Default value from {@code value} for the field. Must be a valid enum constant.
+     *
+     * @return the default enum constant name as a string, defaults to none
      */
     String defaultValue() default "";
 }

--- a/src/main/java/org/kiwiproject/dynamicproperties/annotation/Unit.java
+++ b/src/main/java/org/kiwiproject/dynamicproperties/annotation/Unit.java
@@ -16,11 +16,15 @@ public @interface Unit {
 
     /**
      * Set the concrete list of units allowed for this field.
+     *
+     * @return the units for this field
      */
     String[] value();
 
     /**
      * Default value from {@code value} for the field.
+     *
+     * @return the default value, which defaults to an empty string
      */
     String defaultValue() default "";
 }

--- a/src/main/java/org/kiwiproject/dynamicproperties/jaxrs/resource/PropertyResource.java
+++ b/src/main/java/org/kiwiproject/dynamicproperties/jaxrs/resource/PropertyResource.java
@@ -5,8 +5,7 @@ import static java.util.stream.Collectors.toMap;
 import static org.kiwiproject.base.KiwiStrings.f;
 import static org.kiwiproject.jaxrs.KiwiStandardResponses.standardNotFoundResponse;
 
-import java.util.Map;
-import java.util.Map.Entry;
+import org.kiwiproject.dynamicproperties.PropertyExtractor;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -14,8 +13,8 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-
-import org.kiwiproject.dynamicproperties.PropertyExtractor;
+import java.util.Map;
+import java.util.Map.Entry;
 
 @Path("/kiwi/dynamic-properties")
 @Produces(MediaType.APPLICATION_JSON)
@@ -43,9 +42,9 @@ public class PropertyResource {
     @GET
     public Response getAllProperties() {
         var extractedProperties = dynamicPropertyClasses.entrySet().stream()
-            .collect(toMap(
-                Entry::getKey, 
-                entry -> PropertyExtractor.extractPropertiesFromClass(entry.getValue())));
+                .collect(toMap(
+                        Entry::getKey,
+                        entry -> PropertyExtractor.extractPropertiesFromClass(entry.getValue())));
 
         return Response.ok(extractedProperties).build();
     }

--- a/src/test/java/org/kiwiproject/dynamicproperties/PropertyExtractorTest.java
+++ b/src/test/java/org/kiwiproject/dynamicproperties/PropertyExtractorTest.java
@@ -127,23 +127,23 @@ class PropertyExtractorTest {
             assertThat(properties)
                     .usingRecursiveFieldByFieldElementComparator()
                     .containsExactlyInAnyOrderElementsOf(List.of(
-                       firstNameProperty,
-                       lastNameProperty,
-                       gpaProperty,
-                       schoolProperty,
-                       educationLevelProperty,
-                       favoriteSubjectProperty,
-                       distanceFromSchoolProperty,
-                       weightProperty,
-                       heightProperty,
-                       backpackWeightProperty
+                            firstNameProperty,
+                            lastNameProperty,
+                            gpaProperty,
+                            schoolProperty,
+                            educationLevelProperty,
+                            favoriteSubjectProperty,
+                            distanceFromSchoolProperty,
+                            weightProperty,
+                            heightProperty,
+                            backpackWeightProperty
                     ));
         }
 
         class TooManyUnits {
 
             @DynamicField
-            @Unit({ "foo" })
+            @Unit({"foo"})
             @EnumUnit(Education.class)
             private String unitField;
         }
@@ -158,7 +158,7 @@ class PropertyExtractorTest {
         class InvalidUnitDefault {
 
             @DynamicField
-            @Unit(value = { "foo" }, defaultValue = "bar")
+            @Unit(value = {"foo"}, defaultValue = "bar")
             private String unitField;
         }
 

--- a/src/test/java/org/kiwiproject/dynamicproperties/data/Student.java
+++ b/src/test/java/org/kiwiproject/dynamicproperties/data/Student.java
@@ -33,11 +33,11 @@ public class Student {
     @DynamicField
     private Education educationLevel;
 
-    @DynamicField(choices = { "English", "Geometry", "Physics", "PE", "Art", "Band" })
+    @DynamicField(choices = {"English", "Geometry", "Physics", "PE", "Art", "Band"})
     private String favoriteSubject;
 
     @DynamicField
-    @Unit(value = { "m", "km" }, defaultValue = "km")
+    @Unit(value = {"m", "km"}, defaultValue = "km")
     private Double distanceFromSchool;
 
     @DynamicField
@@ -45,7 +45,7 @@ public class Student {
     private Double weight;
 
     @DynamicField
-    @Unit(value = { "ft", "m" })
+    @Unit(value = {"ft", "m"})
     private Double height;
 
     @DynamicField

--- a/src/test/java/org/kiwiproject/dynamicproperties/jaxrs/resource/PropertyResourceTest.java
+++ b/src/test/java/org/kiwiproject/dynamicproperties/jaxrs/resource/PropertyResourceTest.java
@@ -3,8 +3,8 @@ package org.kiwiproject.dynamicproperties.jaxrs.resource;
 import static org.kiwiproject.test.jaxrs.JaxrsTestHelper.assertNotFoundResponse;
 import static org.kiwiproject.test.jaxrs.JaxrsTestHelper.assertOkResponse;
 
-import java.util.Map;
-
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import io.dropwizard.testing.junit5.ResourceExtension;
 import org.json.JSONException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -14,13 +14,12 @@ import org.kiwiproject.dynamicproperties.data.Student;
 import org.kiwiproject.test.util.Fixtures;
 import org.skyscreamer.jsonassert.JSONAssert;
 
-import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
-import io.dropwizard.testing.junit5.ResourceExtension;
+import java.util.Map;
 
 @ExtendWith(DropwizardExtensionsSupport.class)
 @DisplayName("PropertyResource")
 class PropertyResourceTest {
-    
+
     private static final PropertyResource PROPERTY_RESOURCE = new PropertyResource(Map.of("student", Student.class));
     private static final ResourceExtension RESOURCE = ResourceExtension.builder()
             .bootstrapLogging(false)

--- a/src/test/resources/allProperties.json
+++ b/src/test/resources/allProperties.json
@@ -1,140 +1,140 @@
 {
-    "student": [
-        {
-            "name": "firstName",
-            "label": "",
-            "type": "String",
-            "required": true,
-            "visible": true,
-            "editable": true,
-            "units": null,
-            "defaultUnit": null,
-            "values": []
-        },
-        {
-            "name": "lastName",
-            "label": "",
-            "type": "String",
-            "required": false,
-            "visible": false,
-            "editable": true,
-            "units": null,
-            "defaultUnit": null,
-            "values": []
-        },
-        {
-            "name": "gpa",
-            "label": "",
-            "type": "Double",
-            "required": false,
-            "visible": true,
-            "editable": false,
-            "units": null,
-            "defaultUnit": null,
-            "values": []
-        },
-        {
-            "name": "school",
-            "label": "Currently Enrolled",
-            "type": "String",
-            "required": false,
-            "visible": true,
-            "editable": true,
-            "units": null,
-            "defaultUnit": null,
-            "values": []
-        },
-        {
-            "name": "educationLevel",
-            "label": "",
-            "type": "Education",
-            "required": false,
-            "visible": true,
-            "editable": true,
-            "units": null,
-            "defaultUnit": null,
-            "values": [
-                "HIGH_SCHOOL",
-                "BACHELOR",
-                "MASTER",
-                "PHD"
-            ]
-        },
-        {
-            "name": "favoriteSubject",
-            "label": "",
-            "type": "String",
-            "required": false,
-            "visible": true,
-            "editable": true,
-            "units": null,
-            "defaultUnit": null,
-            "values": [
-                "English",
-                "Geometry",
-                "Physics",
-                "PE",
-                "Art",
-                "Band"
-            ]
-        },
-        {
-            "name": "distanceFromSchool",
-            "label": "",
-            "type": "Double",
-            "required": false,
-            "visible": true,
-            "editable": true,
-            "units": [
-                "m",
-                "km"
-            ],
-            "defaultUnit": "km",
-            "values": []
-        },
-        {
-            "name": "weight",
-            "label": "",
-            "type": "Double",
-            "required": false,
-            "visible": true,
-            "editable": true,
-            "units": [
-                "LBS",
-                "G",
-                "KG"
-            ],
-            "defaultUnit": "LBS",
-            "values": []
-        },
-        {
-            "name": "height",
-            "label": "",
-            "type": "Double",
-            "required": false,
-            "visible": true,
-            "editable": true,
-            "units": [
-                "ft",
-                "m"
-            ],
-            "defaultUnit": "",
-            "values": []
-        },
-        {
-            "name": "backpackWeight",
-            "label": "",
-            "type": "Double",
-            "required": false,
-            "visible": true,
-            "editable": true,
-            "units": [
-                "LBS",
-                "G",
-                "KG"
-            ],
-            "defaultUnit": "",
-            "values": []
-        }
-    ]
+  "student": [
+    {
+      "name": "firstName",
+      "label": "",
+      "type": "String",
+      "required": true,
+      "visible": true,
+      "editable": true,
+      "units": null,
+      "defaultUnit": null,
+      "values": []
+    },
+    {
+      "name": "lastName",
+      "label": "",
+      "type": "String",
+      "required": false,
+      "visible": false,
+      "editable": true,
+      "units": null,
+      "defaultUnit": null,
+      "values": []
+    },
+    {
+      "name": "gpa",
+      "label": "",
+      "type": "Double",
+      "required": false,
+      "visible": true,
+      "editable": false,
+      "units": null,
+      "defaultUnit": null,
+      "values": []
+    },
+    {
+      "name": "school",
+      "label": "Currently Enrolled",
+      "type": "String",
+      "required": false,
+      "visible": true,
+      "editable": true,
+      "units": null,
+      "defaultUnit": null,
+      "values": []
+    },
+    {
+      "name": "educationLevel",
+      "label": "",
+      "type": "Education",
+      "required": false,
+      "visible": true,
+      "editable": true,
+      "units": null,
+      "defaultUnit": null,
+      "values": [
+        "HIGH_SCHOOL",
+        "BACHELOR",
+        "MASTER",
+        "PHD"
+      ]
+    },
+    {
+      "name": "favoriteSubject",
+      "label": "",
+      "type": "String",
+      "required": false,
+      "visible": true,
+      "editable": true,
+      "units": null,
+      "defaultUnit": null,
+      "values": [
+        "English",
+        "Geometry",
+        "Physics",
+        "PE",
+        "Art",
+        "Band"
+      ]
+    },
+    {
+      "name": "distanceFromSchool",
+      "label": "",
+      "type": "Double",
+      "required": false,
+      "visible": true,
+      "editable": true,
+      "units": [
+        "m",
+        "km"
+      ],
+      "defaultUnit": "km",
+      "values": []
+    },
+    {
+      "name": "weight",
+      "label": "",
+      "type": "Double",
+      "required": false,
+      "visible": true,
+      "editable": true,
+      "units": [
+        "LBS",
+        "G",
+        "KG"
+      ],
+      "defaultUnit": "LBS",
+      "values": []
+    },
+    {
+      "name": "height",
+      "label": "",
+      "type": "Double",
+      "required": false,
+      "visible": true,
+      "editable": true,
+      "units": [
+        "ft",
+        "m"
+      ],
+      "defaultUnit": "",
+      "values": []
+    },
+    {
+      "name": "backpackWeight",
+      "label": "",
+      "type": "Double",
+      "required": false,
+      "visible": true,
+      "editable": true,
+      "units": [
+        "LBS",
+        "G",
+        "KG"
+      ],
+      "defaultUnit": "",
+      "values": []
+    }
+  ]
 }

--- a/src/test/resources/studentProperties.json
+++ b/src/test/resources/studentProperties.json
@@ -1,138 +1,138 @@
 [
-    {
-        "name": "firstName",
-        "label": "",
-        "type": "String",
-        "required": true,
-        "visible": true,
-        "editable": true,
-        "units": null,
-        "defaultUnit": null,
-        "values": []
-    },
-    {
-        "name": "lastName",
-        "label": "",
-        "type": "String",
-        "required": false,
-        "visible": false,
-        "editable": true,
-        "units": null,
-        "defaultUnit": null,
-        "values": []
-    },
-    {
-        "name": "gpa",
-        "label": "",
-        "type": "Double",
-        "required": false,
-        "visible": true,
-        "editable": false,
-        "units": null,
-        "defaultUnit": null,
-        "values": []
-    },
-    {
-        "name": "school",
-        "label": "Currently Enrolled",
-        "type": "String",
-        "required": false,
-        "visible": true,
-        "editable": true,
-        "units": null,
-        "defaultUnit": null,
-        "values": []
-    },
-    {
-        "name": "educationLevel",
-        "label": "",
-        "type": "Education",
-        "required": false,
-        "visible": true,
-        "editable": true,
-        "units": null,
-        "defaultUnit": null,
-        "values": [
-            "HIGH_SCHOOL",
-            "BACHELOR",
-            "MASTER",
-            "PHD"
-        ]
-    },
-    {
-        "name": "favoriteSubject",
-        "label": "",
-        "type": "String",
-        "required": false,
-        "visible": true,
-        "editable": true,
-        "units": null,
-        "defaultUnit": null,
-        "values": [
-            "English",
-            "Geometry",
-            "Physics",
-            "PE",
-            "Art",
-            "Band"
-        ]
-    },
-    {
-        "name": "distanceFromSchool",
-        "label": "",
-        "type": "Double",
-        "required": false,
-        "visible": true,
-        "editable": true,
-        "units": [
-            "m",
-            "km"
-        ],
-        "defaultUnit": "km",
-        "values": []
-    },
-    {
-        "name": "weight",
-        "label": "",
-        "type": "Double",
-        "required": false,
-        "visible": true,
-        "editable": true,
-        "units": [
-            "LBS",
-            "G",
-            "KG"
-        ],
-        "defaultUnit": "LBS",
-        "values": []
-    },
-    {
-        "name": "height",
-        "label": "",
-        "type": "Double",
-        "required": false,
-        "visible": true,
-        "editable": true,
-        "units": [
-            "ft",
-            "m"
-        ],
-        "defaultUnit": "",
-        "values": []
-    },
-    {
-        "name": "backpackWeight",
-        "label": "",
-        "type": "Double",
-        "required": false,
-        "visible": true,
-        "editable": true,
-        "units": [
-            "LBS",
-            "G",
-            "KG"
-        ],
-        "defaultUnit": "",
-        "values": []
-    }
+  {
+    "name": "firstName",
+    "label": "",
+    "type": "String",
+    "required": true,
+    "visible": true,
+    "editable": true,
+    "units": null,
+    "defaultUnit": null,
+    "values": []
+  },
+  {
+    "name": "lastName",
+    "label": "",
+    "type": "String",
+    "required": false,
+    "visible": false,
+    "editable": true,
+    "units": null,
+    "defaultUnit": null,
+    "values": []
+  },
+  {
+    "name": "gpa",
+    "label": "",
+    "type": "Double",
+    "required": false,
+    "visible": true,
+    "editable": false,
+    "units": null,
+    "defaultUnit": null,
+    "values": []
+  },
+  {
+    "name": "school",
+    "label": "Currently Enrolled",
+    "type": "String",
+    "required": false,
+    "visible": true,
+    "editable": true,
+    "units": null,
+    "defaultUnit": null,
+    "values": []
+  },
+  {
+    "name": "educationLevel",
+    "label": "",
+    "type": "Education",
+    "required": false,
+    "visible": true,
+    "editable": true,
+    "units": null,
+    "defaultUnit": null,
+    "values": [
+      "HIGH_SCHOOL",
+      "BACHELOR",
+      "MASTER",
+      "PHD"
+    ]
+  },
+  {
+    "name": "favoriteSubject",
+    "label": "",
+    "type": "String",
+    "required": false,
+    "visible": true,
+    "editable": true,
+    "units": null,
+    "defaultUnit": null,
+    "values": [
+      "English",
+      "Geometry",
+      "Physics",
+      "PE",
+      "Art",
+      "Band"
+    ]
+  },
+  {
+    "name": "distanceFromSchool",
+    "label": "",
+    "type": "Double",
+    "required": false,
+    "visible": true,
+    "editable": true,
+    "units": [
+      "m",
+      "km"
+    ],
+    "defaultUnit": "km",
+    "values": []
+  },
+  {
+    "name": "weight",
+    "label": "",
+    "type": "Double",
+    "required": false,
+    "visible": true,
+    "editable": true,
+    "units": [
+      "LBS",
+      "G",
+      "KG"
+    ],
+    "defaultUnit": "LBS",
+    "values": []
+  },
+  {
+    "name": "height",
+    "label": "",
+    "type": "Double",
+    "required": false,
+    "visible": true,
+    "editable": true,
+    "units": [
+      "ft",
+      "m"
+    ],
+    "defaultUnit": "",
+    "values": []
+  },
+  {
+    "name": "backpackWeight",
+    "label": "",
+    "type": "Double",
+    "required": false,
+    "visible": true,
+    "editable": true,
+    "units": [
+      "LBS",
+      "G",
+      "KG"
+    ],
+    "defaultUnit": "",
+    "values": []
+  }
 ]


### PR DESCRIPTION
* Fix several Sonar issues, changing from casts to method references
* Fix javadoc warnings seen during last deployment
* Fix several miscellaneous grammatical errors in javadoc
* Let IntelliJ re-organize imports in our preferred order
* Reformat all code using IntelliJ b/c VSCode sux