### PR TITLE
Add sensitive property to `DynamicField` annotation

### DIFF
--- a/src/main/java/org/kiwiproject/dynamicproperties/Property.java
+++ b/src/main/java/org/kiwiproject/dynamicproperties/Property.java
@@ -17,6 +17,7 @@ public class Property {
     private boolean required;
     private boolean visible;
     private boolean editable;
+    private boolean sensitive;
 
     private List<String> units;
     private String defaultUnit;

--- a/src/main/java/org/kiwiproject/dynamicproperties/PropertyExtractor.java
+++ b/src/main/java/org/kiwiproject/dynamicproperties/PropertyExtractor.java
@@ -40,6 +40,7 @@ public class PropertyExtractor {
                 .editable(dynamicFieldAnnotation.editable())
                 .label(dynamicFieldAnnotation.label())
                 .required(dynamicFieldAnnotation.required())
+                .sensitive(dynamicFieldAnnotation.sensitive())
                 .build();
 
         addUnitInformationIfNecessary(property, field);

--- a/src/main/java/org/kiwiproject/dynamicproperties/annotation/DynamicField.java
+++ b/src/main/java/org/kiwiproject/dynamicproperties/annotation/DynamicField.java
@@ -48,4 +48,11 @@ public @interface DynamicField {
      * @return true if this field is required, false otherwise
      */
     boolean required() default false;
+
+    /**
+     * Informs the caller if this field will have a sensitive value.
+     *
+     * @return true if this field is required, false otherwise
+     */
+    boolean sensitive() default false;
 }

--- a/src/test/java/org/kiwiproject/dynamicproperties/PropertyExtractorTest.java
+++ b/src/test/java/org/kiwiproject/dynamicproperties/PropertyExtractorTest.java
@@ -124,6 +124,15 @@ class PropertyExtractorTest {
                     .defaultUnit("")
                     .build();
 
+            var passwordProperty = Property.builder()
+                    .name("studentPassword")
+                    .label("")
+                    .type("String")
+                    .sensitive(true)
+                    .visible(true)
+                    .editable(true)
+                    .build();
+
             assertThat(properties)
                     .usingRecursiveFieldByFieldElementComparator()
                     .containsExactlyInAnyOrderElementsOf(List.of(
@@ -136,12 +145,14 @@ class PropertyExtractorTest {
                             distanceFromSchoolProperty,
                             weightProperty,
                             heightProperty,
-                            backpackWeightProperty
+                            backpackWeightProperty,
+                            passwordProperty
                     ));
         }
 
         class TooManyUnits {
 
+            @SuppressWarnings("unused")
             @DynamicField
             @Unit({"foo"})
             @EnumUnit(Education.class)
@@ -159,6 +170,7 @@ class PropertyExtractorTest {
 
             @DynamicField
             @Unit(value = {"foo"}, defaultValue = "bar")
+            @SuppressWarnings("unused")
             private String unitField;
         }
 
@@ -173,6 +185,7 @@ class PropertyExtractorTest {
 
             @DynamicField
             @EnumUnit(value = Education.class, defaultValue = "KINDERGARTEN")
+            @SuppressWarnings("unused")
             private String unitField;
         }
 

--- a/src/test/java/org/kiwiproject/dynamicproperties/data/Student.java
+++ b/src/test/java/org/kiwiproject/dynamicproperties/data/Student.java
@@ -4,6 +4,7 @@ import org.kiwiproject.dynamicproperties.annotation.DynamicField;
 import org.kiwiproject.dynamicproperties.annotation.EnumUnit;
 import org.kiwiproject.dynamicproperties.annotation.Unit;
 
+@SuppressWarnings("unused") // This is used for tests
 public class Student {
 
     public enum Education {
@@ -49,5 +50,8 @@ public class Student {
     @DynamicField
     @EnumUnit(WeightUnit.class)
     private Double backpackWeight;
+
+    @DynamicField(sensitive = true)
+    private String studentPassword;
 
 }

--- a/src/test/resources/allProperties.json
+++ b/src/test/resources/allProperties.json
@@ -135,6 +135,18 @@
       ],
       "defaultUnit": "",
       "values": []
+    },
+    {
+      "name": "studentPassword",
+      "label": "",
+      "type": "String",
+      "required": false,
+      "visible": true,
+      "editable": true,
+      "sensitive": true,
+      "units": null,
+      "defaultUnit": null,
+      "values": []
     }
   ]
 }

--- a/src/test/resources/studentProperties.json
+++ b/src/test/resources/studentProperties.json
@@ -134,5 +134,17 @@
     ],
     "defaultUnit": "",
     "values": []
+  },
+  {
+    "name": "studentPassword",
+    "label": "",
+    "type": "String",
+    "required": false,
+    "visible": true,
+    "editable": true,
+    "sensitive": true,
+    "units": null,
+    "defaultUnit": null,
+    "values": []
   }
 ]


### PR DESCRIPTION
This field will indicate to the caller that the property should be treated as a sensitive value such as a password.

Fixes #9