### PR TITLE
Add choicesFromEnum property to provide values based on enum

### DIFF
--- a/src/main/java/org/kiwiproject/dynamicproperties/PropertyExtractor.java
+++ b/src/main/java/org/kiwiproject/dynamicproperties/PropertyExtractor.java
@@ -10,6 +10,7 @@ import static org.kiwiproject.reflect.KiwiReflection.nonStaticFieldsInHierarchy;
 import lombok.experimental.UtilityClass;
 import org.kiwiproject.dynamicproperties.annotation.DynamicField;
 import org.kiwiproject.dynamicproperties.annotation.EnumUnit;
+import org.kiwiproject.dynamicproperties.annotation.NullEnum;
 import org.kiwiproject.dynamicproperties.annotation.Unit;
 
 import java.lang.reflect.Field;
@@ -55,6 +56,10 @@ public class PropertyExtractor {
 
         if (isNotEmpty(dynamicFieldAnnotation.choices())) {
             return Arrays.asList(dynamicFieldAnnotation.choices());
+        }
+
+        if (dynamicFieldAnnotation.choicesFromEnum() != NullEnum.class) {
+            return getListFromEnum(dynamicFieldAnnotation.choicesFromEnum());
         }
 
         return emptyList();

--- a/src/main/java/org/kiwiproject/dynamicproperties/annotation/DynamicField.java
+++ b/src/main/java/org/kiwiproject/dynamicproperties/annotation/DynamicField.java
@@ -43,6 +43,14 @@ public @interface DynamicField {
     String[] choices() default {};
 
     /**
+     * Provide a list of possible values for this field by using the given Enum as the list. Useful if field is
+     * restricted to a set of values.
+     *
+     * @return the choices that should be available for this field base on the given Enum.
+     */
+    Class<? extends Enum<?>> choicesFromEnum() default NullEnum.class;
+
+    /**
      * Informs the caller if this field is required.
      *
      * @return true if this field is required, false otherwise

--- a/src/main/java/org/kiwiproject/dynamicproperties/annotation/DynamicField.java
+++ b/src/main/java/org/kiwiproject/dynamicproperties/annotation/DynamicField.java
@@ -48,7 +48,7 @@ public @interface DynamicField {
      *
      * @return the choices that should be available for this field base on the given Enum.
      */
-    Class<? extends Enum<?>> choicesFromEnum() default NullEnum.class;
+    Class<? extends Enum> choicesFromEnum() default NullEnum.class;
 
     /**
      * Informs the caller if this field is required.

--- a/src/main/java/org/kiwiproject/dynamicproperties/annotation/NullEnum.java
+++ b/src/main/java/org/kiwiproject/dynamicproperties/annotation/NullEnum.java
@@ -1,0 +1,8 @@
+package org.kiwiproject.dynamicproperties.annotation;
+
+/**
+ * Dummy enum class used as default value for optional attributes of
+ * annotations.
+ */
+public enum NullEnum {
+}

--- a/src/test/java/org/kiwiproject/dynamicproperties/PropertyExtractorTest.java
+++ b/src/test/java/org/kiwiproject/dynamicproperties/PropertyExtractorTest.java
@@ -70,6 +70,16 @@ class PropertyExtractorTest {
                     .values(List.of("HIGH_SCHOOL", "BACHELOR", "MASTER", "PHD"))
                     .build();
 
+            var highestEducationLevelProperty = Property.builder()
+                    .name("highestEducationLevel")
+                    .label("")
+                    .type("String")
+                    .required(false)
+                    .visible(true)
+                    .editable(true)
+                    .values(List.of("HIGH_SCHOOL", "BACHELOR", "MASTER", "PHD"))
+                    .build();
+
             var favoriteSubjectProperty = Property.builder()
                     .name("favoriteSubject")
                     .label("")
@@ -141,6 +151,7 @@ class PropertyExtractorTest {
                             gpaProperty,
                             schoolProperty,
                             educationLevelProperty,
+                            highestEducationLevelProperty,
                             favoriteSubjectProperty,
                             distanceFromSchoolProperty,
                             weightProperty,

--- a/src/test/java/org/kiwiproject/dynamicproperties/data/Student.java
+++ b/src/test/java/org/kiwiproject/dynamicproperties/data/Student.java
@@ -32,6 +32,9 @@ public class Student {
     @DynamicField
     private Education educationLevel;
 
+    @DynamicField(choicesFromEnum = Education.class)
+    private String highestEducationLevel;
+
     @DynamicField(choices = {"English", "Geometry", "Physics", "PE", "Art", "Band"})
     private String favoriteSubject;
 

--- a/src/test/resources/allProperties.json
+++ b/src/test/resources/allProperties.json
@@ -61,6 +61,22 @@
       ]
     },
     {
+      "name": "highestEducationLevel",
+      "label": "",
+      "type": "String",
+      "required": false,
+      "visible": true,
+      "editable": true,
+      "units": null,
+      "defaultUnit": null,
+      "values": [
+        "HIGH_SCHOOL",
+        "BACHELOR",
+        "MASTER",
+        "PHD"
+      ]
+    },
+    {
       "name": "favoriteSubject",
       "label": "",
       "type": "String",

--- a/src/test/resources/studentProperties.json
+++ b/src/test/resources/studentProperties.json
@@ -60,6 +60,22 @@
     ]
   },
   {
+    "name": "highestEducationLevel",
+    "label": "",
+    "type": "String",
+    "required": false,
+    "visible": true,
+    "editable": true,
+    "units": null,
+    "defaultUnit": null,
+    "values": [
+      "HIGH_SCHOOL",
+      "BACHELOR",
+      "MASTER",
+      "PHD"
+    ]
+  },
+  {
     "name": "favoriteSubject",
     "label": "",
     "type": "String",


### PR DESCRIPTION
There are now 3 ways to determine possible values for a field:

1. If the type of field is an Enum, it will set the values based on the possible items from the Enum
2. If the type of field is a String and if the `choices` attribute is specified it will use that list (must be Strings)
3. If the type of field is a String and if the `choicesFromEnum` attribute is used, it will use set the values based on the items from the Enum

Otherwise it will be an empty list.

Closes #11 