### PR TITLE
Add explicit PR types to CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,6 +17,7 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "main" ]
+    types: [ opened, synchronize, reopened ]
   schedule:
     - cron: '36 23 * * 3'
 


### PR DESCRIPTION
Add explicit pull request types for CodeQL workflow. These are the defaults, but this makes it more clear, and guards against any future changes in the default values (however unlikely that may be).