### PR TITLE
Don't run builds when only md/txt files changed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
       - main
   pull_request:
     types: [ opened, synchronize, reopened ]
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.txt'
 jobs:
   build:
     name: Build

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,6 +18,9 @@ on:
     # The branches below must be a subset of the branches above
     branches: [ "main" ]
     types: [ opened, synchronize, reopened ]
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.txt'
   schedule:
     - cron: '36 23 * * 3'
 


### PR DESCRIPTION
If only a Mardown or a text file was changed, no need to run build in pull requests