### PR TITLE
Update parent POM and BOM for JDK 17 and major library updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [ '11', '17', '20' ]
+        java_version: [ '17', '20' ]
     steps:
       # Check out the project
       - uses: actions/checkout@v3
@@ -33,7 +33,7 @@ jobs:
       # Cache all the things
       - name: Cache SonarCloud packages
         uses: actions/cache@v3
-        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '11' }}
+        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '17' }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
@@ -54,16 +54,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         run: mvn -B -V compile
 
-      # Run tests when Java version > 11 (Sonar runs tests and analysis on JDK 11)
+      # Run tests when Java version > 17 (Sonar runs tests and analysis on JDK 17)
       - name: Run tests
-        if: ${{ matrix.java_version != '11' }}
+        if: ${{ matrix.java_version != '17' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         run: mvn -B -V verify
 
-      # Run Sonar Analysis (on Java version 11 only)
+      # Run Sonar Analysis (on Java version 17 only)
       - name: Analyze with SonarCloud
-        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '11' }}
+        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '17' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,6 +33,12 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
+    - name: Set up Java 17
+      uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: 17
+
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:

--- a/pom.xml
+++ b/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>org.kiwiproject</groupId>
         <artifactId>kiwi-parent</artifactId>
-        <version>2.0.20</version>
+        <version>3.0.1</version>
     </parent>
 
     <artifactId>dynamic-properties-provider</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -29,14 +29,14 @@
 
     <properties>
         <!-- Versions for required dependencies -->
-        <kiwi.version>2.7.0</kiwi.version>
-        <kiwi-bom.version>1.1.1</kiwi-bom.version>
+        <kiwi.version>3.0.0</kiwi.version>
+        <kiwi-bom.version>2.0.0</kiwi-bom.version>
 
         <!-- Versions for provided dependencies -->
-        <jakarta.ws.rs-api.version>2.1.6</jakarta.ws.rs-api.version>
+        <!-- nothing here yet... -->
 
         <!-- Versions for test dependencies -->
-        <kiwi-test.version>2.4.0</kiwi-test.version>
+        <kiwi-test.version>3.0.0</kiwi-test.version>
 
         <!-- Sonar properties -->
         <sonar.projectKey>kiwiproject_dynamic-properties-provider</sonar.projectKey>
@@ -80,7 +80,6 @@
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
-            <version>${jakarta.ws.rs-api.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/org/kiwiproject/dynamicproperties/PropertyExtractor.java
+++ b/src/main/java/org/kiwiproject/dynamicproperties/PropertyExtractor.java
@@ -2,13 +2,11 @@ package org.kiwiproject.dynamicproperties;
 
 import static java.util.Arrays.stream;
 import static java.util.Collections.emptyList;
-import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.ArrayUtils.isNotEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.kiwiproject.reflect.KiwiReflection.nonStaticFieldsInHierarchy;
 
 import lombok.experimental.UtilityClass;
-
 import org.kiwiproject.dynamicproperties.annotation.ChoiceSupplier;
 import org.kiwiproject.dynamicproperties.annotation.DynamicField;
 import org.kiwiproject.dynamicproperties.annotation.EnumUnit;
@@ -28,7 +26,7 @@ public class PropertyExtractor {
         return nonStaticFieldsInHierarchy(clazz).stream()
                 .filter(field -> isNotEmpty(field.getAnnotationsByType(DynamicField.class)))
                 .map(PropertyExtractor::convertFieldToProperty)
-                .collect(toList());
+                .toList();
     }
 
     private static Property convertFieldToProperty(Field field) {
@@ -95,7 +93,7 @@ public class PropertyExtractor {
         return stream(enumClass.getEnumConstants())
                 .filter(val -> val instanceof Enum)
                 .map(val -> ((Enum<?>) val).name())
-                .collect(toList());
+                .toList();
     }
 
     private static DynamicField findDynamicFieldAnnotation(Field field) {

--- a/src/main/java/org/kiwiproject/dynamicproperties/annotation/ChoiceSupplier.java
+++ b/src/main/java/org/kiwiproject/dynamicproperties/annotation/ChoiceSupplier.java
@@ -18,7 +18,7 @@ public interface ChoiceSupplier extends Supplier<List<Choice>> {
      * @return a list of choices
      * @throws IllegalArgumentException if the given type is not a valid ChoiceSupplier class
      */
-    public static List<Choice> getChoices(Class<? extends ChoiceSupplier> choiceSupplierClass) {
+    static List<Choice> getChoices(Class<? extends ChoiceSupplier> choiceSupplierClass) {
         checkArgumentNotNull(choiceSupplierClass);
 
         try {

--- a/src/main/java/org/kiwiproject/dynamicproperties/jaxrs/resource/PropertyResource.java
+++ b/src/main/java/org/kiwiproject/dynamicproperties/jaxrs/resource/PropertyResource.java
@@ -5,14 +5,14 @@ import static java.util.stream.Collectors.toMap;
 import static org.kiwiproject.base.KiwiStrings.f;
 import static org.kiwiproject.jaxrs.KiwiStandardResponses.standardNotFoundResponse;
 
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.kiwiproject.dynamicproperties.PropertyExtractor;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 import java.util.Map;
 import java.util.Map.Entry;
 

--- a/src/test/java/org/kiwiproject/dynamicproperties/PropertyExtractorTest.java
+++ b/src/test/java/org/kiwiproject/dynamicproperties/PropertyExtractorTest.java
@@ -188,7 +188,7 @@ class PropertyExtractorTest {
                     ));
         }
 
-        class TooManyUnits {
+        static class TooManyUnits {
 
             @SuppressWarnings("unused")
             @DynamicField
@@ -204,7 +204,7 @@ class PropertyExtractorTest {
                     .hasMessage("@Unit and @EnumUnit are mutually exclusive but both exist.");
         }
 
-        class InvalidUnitDefault {
+        static class InvalidUnitDefault {
 
             @DynamicField
             @Unit(value = {"foo"}, defaultValue = "bar")
@@ -219,7 +219,7 @@ class PropertyExtractorTest {
                     .hasMessage("Unit default value is not a valid value.");
         }
 
-        class InvalidEnumUnitDefault {
+        static class InvalidEnumUnitDefault {
 
             @DynamicField
             @EnumUnit(value = Education.class, defaultValue = "KINDERGARTEN")
@@ -270,11 +270,11 @@ class PropertyExtractorTest {
                     .contains(departmentProperty);
         }
 
-        class TooManyChoices {
+        static class TooManyChoices {
             @DynamicField(choices = {"one", "two"}, choiceSupplier = TooManyChoicesSupplier.class)
             private String thereCanBeOnlyOne;
 
-            class TooManyChoicesSupplier implements ChoiceSupplier {
+            static class TooManyChoicesSupplier implements ChoiceSupplier {
                 @Override
                 public List<Choice> get() {
                     return List.of();


### PR DESCRIPTION
* Bump version to 2.0.0-SNAPSHOT
* Bump kiwi-parent from 2.0.20 to 3.0.1
* Bump kiwi-bom from 1.1.1 to 2.0.0
* Bump kiwi libraries to next major version
* Update build for JDK 17 and 20
* Update CodeQL workflow to use JDK 17
* Fix Dropwizard package changes
* Refactor from javax to jakarta namespace for Jakarta EE 9
* Misc code cleanup (Sonar and IntelliJ inspections)