### PR TITLE
Add dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,17 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      dev-deps:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+      prod-deps:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
     assignees:
       - "chrisrohr"
       - "sleberknight"
@@ -15,6 +26,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      actions-deps:
+        patterns:
+          - "*"
     assignees:
       - "chrisrohr"
       - "sleberknight"


### PR DESCRIPTION
Modify dependabot configuration to group updates for minor and patch versions, splitting dev and prod dependencies.